### PR TITLE
Use YAML::Syck, don't spit out debug output, use DNSimple-compliant TTLs

### DIFF
--- a/bin/import_zone
+++ b/bin/import_zone
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+YAML::ENGINE.yamler = 'syck'
+
 require 'optparse'
 $:.unshift('lib')
 

--- a/lib/dnsimple/bind/zone_importer.rb
+++ b/lib/dnsimple/bind/zone_importer.rb
@@ -12,7 +12,7 @@ module DNSimple
       end
 
       def import_from_string(s, name=nil)
-        DNSimple::Domain.debug_output $stdout
+        DNSimple::Domain.debug_output $stdout if ENV['DNSSIMPLE_DEBUG']
         
         zone = DNS::Zonefile.load(s, name)
         puts "origin: #{name}"
@@ -26,38 +26,39 @@ module DNSimple
         puts "domain name: #{domain.name}"
 
         zone.records.each do |r|
+          ttl = dnsimple_ttl r.ttl
           case r
           when DNS::A then
-            puts "A record: #{r.host} -> #{r.address} (ttl: #{r.ttl})"
-            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'A', r.address, :ttl => r.ttl) 
+            puts "A record: #{r.host} -> #{r.address} (ttl: #{ttl}, orig #{r.ttl})"
+            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'A', r.address, :ttl => ttl) 
           when DNS::AAAA then
-            puts "AAAA record: #{r.host} -> #{r.address} (ttl: #{r.ttl})"
-            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'AAAA', r.address, :ttl => r.ttl)
+            puts "AAAA record: #{r.host} -> #{r.address} (ttl: #{ttl}, orig #{r.ttl})"
+            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'AAAA', r.address, :ttl => ttl)
           when DNS::CNAME then
-            puts "CNAME record: #{r.host} -> #{r.domainname} (ttl: #{r.ttl})"
-            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'CNAME', r.domainname, :ttl => r.ttl)
+            puts "CNAME record: #{r.host} -> #{r.domainname} (ttl: #{ttl}, orig #{r.ttl})"
+            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'CNAME', r.domainname, :ttl => ttl)
           when DNS::NS then
             if host_name(r.host, domain.name).blank?
               puts "Skip NS record for SLD: #{r.host} -> #{r.domainname}"
             else
-              puts "NS record: #{r.host} -> #{r.domainname} (ttl: #{r.ttl})"
-              DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'NS', r.domainname, :ttl => r.ttl)
+              puts "NS record: #{r.host} -> #{r.domainname} (ttl: #{ttl}, orig #{r.ttl})"
+              DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'NS', r.domainname, :ttl => ttl)
             end
           when DNS::PTR then
-            puts "PTR record: #{r.host} -> #{r.domainname} (ttl: #{r.ttl})"
-            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'CNAME', r.domainname, :ttl => r.ttl)
+            puts "PTR record: #{r.host} -> #{r.domainname} (ttl: #{ttl}, orig #{r.ttl})"
+            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'CNAME', r.domainname, :ttl => ttl)
           when DNS::MX then
-            puts "MX record: #{r.host} -> #{r.domainname} (prio: #{r.priority}, ttl: #{r.ttl})"
-            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'MX', r.domainname, :ttl => r.ttl, :prio => r.priority)
+            puts "MX record: #{r.host} -> #{r.domainname} (prio: #{r.priority}, ttl: #{ttl}, orig #{r.ttl})"
+            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'MX', r.domainname, :ttl => ttl, :prio => r.priority)
           when DNS::TXT then
-            puts "TXT record: #{r.host} -> #{r.data} (ttl: #{r.ttl})"
-            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'TXT', r.data, :ttl => r.ttl)
+            puts "TXT record: #{r.host} -> #{r.data} (ttl: #{ttl}, orig #{r.ttl})"
+            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'TXT', r.data, :ttl => ttl)
           when DNS::SRV then
-            puts "SRV record: #{r.host} -> #{r.domainname} (prio: #{r.priority}, weight: #{r.weight}, port: #{r.port}, ttl: #{r.ttl})"
-            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'SRV', "#{r.weight} #{r.port} #{r.domainname}", :ttl => r.ttl, :prio => r.priority)
+            puts "SRV record: #{r.host} -> #{r.domainname} (prio: #{r.priority}, weight: #{r.weight}, port: #{r.port}, ttl: #{ttl}, orig #{r.ttl})"
+            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'SRV', "#{r.weight} #{r.port} #{r.domainname}", :ttl => ttl, :prio => r.priority)
           when DNS::NAPTR then
-            puts "NAPTR record: #{r.host} -> #{t.data} (ttl: #{r.ttl})"
-            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'NAPTR', r.data, :ttl => r.ttl)
+            puts "NAPTR record: #{r.host} -> #{t.data} (ttl: #{ttl}, orig #{r.ttl})"
+            DNSimple::Record.create(domain.name, host_name(r.host, domain.name), 'NAPTR', r.data, :ttl => ttl)
           end
         end
       end
@@ -70,7 +71,12 @@ module DNSimple
         n = n.gsub(/\.db/, '')
         n = n.gsub(/\.txt/, '')
       end
-
+      
+      VALID_TTLS = [60, 600, 3600, 86400]
+      def dnsimple_ttl ttl
+        VALID_TTLS.detect {|a| a >= ttl} || VALID_TTLS.last
+      end
+        
     end
   end
 end


### PR DESCRIPTION
Apologies that these commits aren't as atomic as they could be, but they're small changes.

YAML::Psych didn't work for me with Crack::JSON, so I enforced Syck in the importer.

Made it so debug output from Net::HTTP won't be printed unless an environment variable is present.

Rounded up TTLs to match those in the DNSimple web ui.
